### PR TITLE
install and install-strip target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,7 @@ semeru: semeru.o
 
 clean:
 	rm -f *.o semeru
+
+install: all
+	mkdir -p $(DESTDIR)/usr/sbin/
+	install -m 755 semeru $(DESTDIR)/usr/sbin/

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ all: semeru
 
 semeru: semeru.o
 	$(CC) $^ $(LDFLAGS) -o $@
-	strip $@
 
 clean:
 	rm -f *.o semeru
@@ -28,3 +27,7 @@ clean:
 install: all
 	mkdir -p $(DESTDIR)/usr/sbin/
 	install -m 755 semeru $(DESTDIR)/usr/sbin/
+
+install-strip: all
+	mkdir -p $(DESTDIR)/usr/sbin/
+	install -s -m 755 semeru $(DESTDIR)/usr/sbin/


### PR DESCRIPTION
Didn't want the binary to always be stripped when building, so added a install and install-strip target and removed the strip part from the semeru target.
